### PR TITLE
Use python3 interpreter from env

### DIFF
--- a/pdfminify
+++ b/pdfminify
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #	pdfminify - Tool to minify PDF files.
 #	Copyright (C) 2016-2016 Johannes Bauer
 #


### PR DESCRIPTION
Using `/usr/bin/env python3` will ensure that the `python3` defined in in the current environment's $PATH is used, not the system interpreter.